### PR TITLE
Reference the todo index in toggleTodo correctly

### DIFF
--- a/docs/v3.x/todo-app/index.md
+++ b/docs/v3.x/todo-app/index.md
@@ -485,9 +485,7 @@ export const template = (ctx, html) => html`
 ...
 class HomePage extends AoflElement {
   ...
-    toggleTodo(e) {
-    const index = parseInt(e.target.dataset.index, 10);
-
+  toggleTodo(e, index) {
     todosSdo.toggleComplete(index);
   }
   ...


### PR DESCRIPTION
Previously we were attempting to get the index from the e.target.dataset object but that object is empty when we receive it in toggleTodo. Instead, if you look at the template we see that both the event object and the index is passed onto toggleTodo. Therefore, we only need the index to reference the correct index of the todo to toggle.

Fixes #

## Proposed Changes

  -
  -
  -
