### PR TITLE
Replace deprecated eslint.autoFixOnSave

### DIFF
--- a/docs/v3.x/housekeeping/ide-setup.md
+++ b/docs/v3.x/housekeeping/ide-setup.md
@@ -19,6 +19,7 @@ The AofL JS team primarily codes on VS Code. If you would like to include setup 
 // Overwrite settings by placing them into your settings file.
 {
   "files.trimTrailingWhitespace": true,
+  "editor.codeActionsOnSave": { "source.fixAll.eslint": true },
   "editor.tabSize": 2,
   "editor.rulers": [100, 120],
   "editor.wordWrapColumn": 120,
@@ -30,7 +31,6 @@ The AofL JS team primarily codes on VS Code. If you would like to include setup 
   "[typescript]": {
     "editor.formatOnSave": false
   },
-  "eslint.autoFixOnSave": true,
   "eslint.alwaysShowStatus": true,
   "docthis.inferTypesFromNames": true,
   "docthis.includeMemberOfOnClassMembers": false,


### PR DESCRIPTION
`eslint.autoFixOnSave` was deprecated in November 2019. The extension's instructions say to replace it with `editor.codeActionsOnSave`:

https://github.com/microsoft/vscode-eslint/commit/13001cf9866fd8d6e41bbaff1afdf06008956f1d#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R126